### PR TITLE
Use AWS_S3_ENDPOINT_URL to read the URL directly

### DIFF
--- a/master_Process_S1_example.ipynb
+++ b/master_Process_S1_example.ipynb
@@ -58,7 +58,7 @@
     "\n",
     "os.environ['ASF_USERNAME']= str(pd.read_csv('../aws_creds.csv').ASF_USERNAME.values[0])\n",
     "os.environ['ASF_PWD']=str(pd.read_csv('../aws_creds.csv').ASF_PWD.values[0])\n",
-    "os.environ['AWS_S3_ENDPOINT']= \"s3-uk-1.sa-catapult.co.uk\"\n",
+    "os.environ['AWS_S3_ENDPOINT_URL']= \"http://s3-uk-1.sa-catapult.co.uk\"\n",
     "\n",
     "os.environ['S1_PROCESS_P1A'] = \"/home/tjones/IPP_Common_Sensing/ard-workflows-tj/utils/cs_s1_pt1_bnr_Orb_Cal_ML.xml\"\n",
     "os.environ['S1_PROCESS_P2A'] = \"/home/tjones/IPP_Common_Sensing/ard-workflows-tj/utils/cs_s1_pt2A_TF.xml\"\n",

--- a/utils/prep_utils.py
+++ b/utils/prep_utils.py
@@ -284,20 +284,19 @@ def s3_create_client(s3_bucket):
         secret,
     )
 
-    endpoint = os.getenv("AWS_S3_ENDPOINT")
+    endpoint_url = os.getenv("AWS_S3_ENDPOINT_URL")
 
-    if endpoint is not None:
-        endpoint_url=f"http://{endpoint}"
+    if endpoint_url is not None:
         logging.debug('Endpoint URL: {}'.format(endpoint_url))
 
-    if endpoint is not None:
+    if endpoint_url is not None:
         s3 = session.resource('s3', endpoint_url=endpoint_url)
     else:
         s3 = session.resource('s3', region_name='eu-west-2')
 
     bucket = s3.Bucket(s3_bucket)
 
-    if endpoint is not None:
+    if endpoint_url is not None:
         s3_client = boto3.client(
             's3',
             aws_access_key_id=access,


### PR DESCRIPTION
Use AWS_S3_ENDPOINT_URL to read the URL directly instead of building it from AWS_S3_ENDPOINT and assuming HTTP over HTTPS